### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_game.yml
+++ b/.github/workflows/build_game.yml
@@ -1,4 +1,6 @@
 name: Build GameMaker Game
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/adrianTotolici/PixelAdventure/security/code-scanning/1](https://github.com/adrianTotolici/PixelAdventure/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow appears to only check out code and build the project, it likely only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow (just after the `name` key and before `on:`), which will apply to all jobs in the workflow. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
