### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Run on Push
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/adrianTotolici/PixelAdventure/security/code-scanning/2](https://github.com/adrianTotolici/PixelAdventure/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow to restrict the permissions granted to the GITHUB_TOKEN. Since the workflow only checks out code and lists files, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. This block can be added at the workflow root (top-level, before `jobs:`) to apply to all jobs, or at the job level if you want to restrict permissions for a specific job. In this case, adding it at the root is simplest and most effective. You only need to edit the `.github/workflows/build.yml` file, inserting the following block:

```yaml
permissions:
  contents: read
```

This should be placed after the `name:` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
